### PR TITLE
[FIX] Do not allow keyStorage to deinit early in JavaHashMapKeyedContainer

### DIFF
--- a/Sources/JavaEncoder.swift
+++ b/Sources/JavaEncoder.swift
@@ -274,6 +274,10 @@ fileprivate class JavaHashMapKeyedContainer<K : CodingKey> : KeyedEncodingContai
         
         let valueStorage = try self.encoder.box(value)
         let result = JNI.CallObjectMethod(javaObject, methodID: HashMapPutMethod, args: [jvalue(l: keyStorage.javaObject), jvalue(l: valueStorage.javaObject)])
+
+        //Do not delete next line, as during runtime keyStorage is deinit before JVM uses the javaObject and crashes.
+        let _ = keyStorage
+        
         assert(result == nil, "Rewrite for key \(key.stringValue)")
     }
     


### PR DESCRIPTION
**Problem:**

When `jniDebbuggable` is `false`, Swift deinit faster the JNI Local Ref keyStorage so when JVM tries to access it is already deleted.

With the proposed solution we keep the keyStorage from calling the deinit method until JNI call is completed.


Crash Log:
```
A/readdle.weathe: indirect_reference_table.cc:63] JNI ERROR (app bug): accessed deleted Local 0x71
A/readdle.weathe: runtime.cc:655] Runtime aborting...
    runtime.cc:655] All threads:
    runtime.cc:655] DALVIK THREADS (18):
    runtime.cc:655] "main" prio=10 tid=1 Runnable
    runtime.cc:655]   | group="" sCount=0 dsCount=0 flags=0 obj=0x725b5c28 self=0xdadc0e10
    runtime.cc:655]   | sysTid=15723 nice=-10 cgrp=top-app sched=0/0 handle=0xe945f478
    runtime.cc:655]   | state=R schedstat=( 104580217 76329615 87 ) utm=3 stm=6 core=1 HZ=100
    runtime.cc:655]   | stack=0xff7b5000-0xff7b7000 stackSize=8192KB
    runtime.cc:655]   | held mutexes= "abort lock" "mutator lock"(shared held)
    runtime.cc:655]   native: #00 pc 00542d9e  /apex/com.android.art/lib/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, int, BacktraceMap*, char const*, art::ArtMethod*, void*, bool)+110)
    runtime.cc:655]   native: #01 pc 006a0897  /apex/com.android.art/lib/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, bool, BacktraceMap*, bool) const+1015)
    runtime.cc:655]   native: #02 pc 0069a171  /apex/com.android.art/lib/libart.so (art::Thread::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, bool, BacktraceMap*, bool) const+65)
    runtime.cc:655]   native: #03 pc 006c61b4  /apex/com.android.art/lib/libart.so (art::DumpCheckpoint::Run(art::Thread*)+1172)
    runtime.cc:655]   native: #04 pc 006bf266  /apex/com.android.art/lib/libart.so (art::ThreadList::RunCheckpoint(art::Closure*, art::Closure*)+630)
    runtime.cc:655]   native: #05 pc 006bdf72  /apex/com.android.art/lib/libart.so (art::ThreadList::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, bool)+1842)
    runtime.cc:655]   native: #06 pc 0065227d  /apex/com.android.art/lib/libart.so (art::AbortState::DumpAllThreads(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, art::Thread*) const+445)
    runtime.cc:655]   native: #07 pc 0063984f  /apex/com.android.art/lib/libart.so (art::Runtime::Abort(char const*)+1967)
    runtime.cc:655]   native: #08 pc 00025a23  /apex/com.android.art/lib/libartbase.so (std::__1::__function::__func<void (*)(char const*), std::__1::allocator<void (*)(char const*)>, void (char const*)>::operator()(char const*&&)+35)
    runtime.cc:655]   native: #09 pc 0001588f  /system/lib/libbase.so (android::base::SetAborter(std::__1::function<void (char const*)>&&)::$_3::__invoke(char const*)+79)
    runtime.cc:655]   native: #10 pc 00006291  /system/lib/liblog.so (__android_log_call_aborter+33)
    runtime.cc:655]   native: #11 pc 00014d14  /system/lib/libbase.so (android::base::LogMessage::~LogMessage()+436)
    runtime.cc:655]   native: #12 pc 00360ce6  /apex/com.android.art/lib/libart.so (art::IndirectReferenceTable::AbortIfNoCheckJNI(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)+262)
    runtime.cc:655]   native: #13 pc 0040dcbd  /apex/com.android.art/lib/libart.so (art::IndirectReferenceTable::GetChecked(void*) const+493)
    runtime.cc:655]   native: #14 pc 006a8199  /apex/com.android.art/lib/libart.so (art::Thread::DecodeJObject(_jobject*) const+105)
    runtime.cc:655]   native: #15 pc 0062f036  /apex/com.android.art/lib/libart.so (art::(anonymous namespace)::ArgArray::BuildArgArrayFromJValues(art::ScopedObjectAccessAlreadyRunnable const&, art::ObjPtr<art::mirror::Object>, jvalue const*)+230)
    runtime.cc:655]   native: #16 pc 0062f349  /apex/com.android.art/lib/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithJValues<art::ArtMethod*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, art::ArtMethod*, jvalue const*)+569)
    runtime.cc:655]   native: #17 pc 0062f595  /apex/com.android.art/lib/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithJValues<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, jvalue const*)+85)
    runtime.cc:655]   native: #18 pc 0042512e  /apex/com.android.art/lib/libart.so (art::JNI<false>::CallObjectMethodA(_JNIEnv*, _jobject*, _jmethodID*, jvalue const*)+782)
    runtime.cc:655]   native: #19 pc 0005ae52  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk (offset 6b06000) ($s10java_swift7JNICoreC9JavaCoderE16CallObjectMethod_8methodID4argss13OpaquePointerVSgAI_AISaySo6jvalueVGtF+210)
    runtime.cc:655]   native: #20 pc 000998ca  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk (offset 6b06000) ($s9JavaCoder0A21HashMapKeyedContainer33_7D23EC59731EF339FB675804D94FFBCCLLC6encode_6forKeyyqd___xtKSERd__lF+1178)
    runtime.cc:655]   native: #21 pc 00099dc1  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk (offset 6b06000) ($s9JavaCoder0A21HashMapKeyedContainer33_7D23EC59731EF339FB675804D94FFBCCLLCyxGs0e8EncodingF8ProtocolAAsAFP6encode_6forKeyyqd___0Q0QztKSERd__lFTW+49)
    runtime.cc:655]   native: #22 pc 00141e75  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk!libswiftCore.so (offset 7bc000) ($ss26_KeyedEncodingContainerBoxC6encode_6forKeyyqd___qd_0_tKSERd__s06CodingG0Rd_0_r0_lF+165)
    runtime.cc:655]   native: #23 pc 0014fa8b  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk!libswiftCore.so (offset 7bc000) ($sSDsSERzSER_rlE6encode2toys7Encoder_p_tKF+1835)
    runtime.cc:655]   native: #24 pc 001504a4  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk!libswiftCore.so (offset 7bc000) ($sSDyxq_GSEsSERzSER_rlSE6encode2toys7Encoder_p_tKFTW+84)
    runtime.cc:655]   native: #25 pc 00394a8a  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk!libswiftCore.so (offset 7bc000) ($sSE6encode2toys7Encoder_p_tKFTj+42)
    runtime.cc:655]   native: #26 pc 00095c9d  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk (offset 6b06000) ($s9JavaCoder0A7EncoderC3box33_7D23EC59731EF339FB675804D94FFBCCLL_10codingPathAA16JNIStorageObjectCx_Says9CodingKey_pGtKSERzlF+5069)
    runtime.cc:655]   native: #27 pc 0008da92  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk (offset 6b06000) ($s9JavaCoder0A7EncoderC6encodeys13OpaquePointerVxKSERzlF+130)
    runtime.cc:655]   native: #28 pc 000ba9e2  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk (offset 6b06000) ($s17WeatherCoreBridge9SSLHelperC9setupCert8basePathySS_tFZ+642)
    runtime.cc:655]   native: #29 pc 00048bff  /data/app/~~RWxplwEY5K1yA3awjlsE3w==/com.readdle.weather-NIsHHhZzTxut2U48WyjF3Q==/base.apk (offset 6b06000) (Java_com_readdle_weather_core_SSLHelper_setupCert__Ljava_lang_String_2+591)
    runtime.cc:655]   at com.readdle.weather.core.SSLHelper.setupCert(Native method)
    runtime.cc:655]   at com.readdle.weather.core.SSLHelper$Companion.setupCert(SSLHelper.kt:-1)
    runtime.cc:655]   at com.readdle.weather.WeatherApp.onCreate(WeatherApp.kt:17)
    runtime.cc:655]   at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1192)
    runtime.cc:655]   at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6712)
    runtime.cc:655]   at android.app.ActivityThread.access$1300(ActivityThread.java:237)
    runtime.cc:655]   at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1913)
    runtime.cc:655]   at android.os.Handler.dispatchMessage(Handler.java:106)
    runtime.cc:655]   at android.os.Looper.loop(Looper.java:223)
    runtime.cc:655]   at android.app.ActivityThread.main(ActivityThread.java:7656)
    runtime.cc:655]   at java.lang.reflect.Method.invoke(Native method)
    runtime.cc:655]   at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
    runtime.cc:655]   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```
